### PR TITLE
Fix issue with UTF-8 encoding crash.

### DIFF
--- a/.github/workflows/push_checks.yml
+++ b/.github/workflows/push_checks.yml
@@ -3,7 +3,7 @@ on: push
 
 jobs:
   rspec:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:
       - name: Set up Ruby 2.3
         run: |

--- a/app/models/listeners/employer_digest_payment_processor_listener.rb
+++ b/app/models/listeners/employer_digest_payment_processor_listener.rb
@@ -44,10 +44,23 @@ module Listeners
     end
 
     def on_message(delivery_info, properties, payload)
-      digest_xml = payload
+      digest_xml = fix_encoding(payload)
       headers = properties.headers || {}
       carrier_profile_name = headers["carrier_profile_name"]
       publish_single_legacy_xml(delivery_info, headers, carrier_profile_name, digest_xml)
+    end
+
+    def fix_encoding(xml)
+      return xml if xml.nil? || xml.blank?
+      if [Encoding::ASCII_8BIT].include?(xml.encoding)
+        xml.force_encoding(Encoding::UTF_8)
+      else
+        xml
+      end
+    end
+
+    def __check_encoding(string)
+      [Encoding::ASCII_8BIT].include?(string.encoding)
     end
 
     def self.queue_name


### PR DESCRIPTION
Sometimes the RabbitMQ listener tries to read the XML as ASCII even if it's encoded otherwise.  Convince it to use the right encoding, given we only ever send UTF8.