### PR TITLE
Update curam timeout.

### DIFF
--- a/amqp/curam_application_completed_listener.rb
+++ b/amqp/curam_application_completed_listener.rb
@@ -1,1 +1,1 @@
-Forkr.new(Listeners::CuramApplicationCompletedListener, 10).run
+Listeners::CuramApplicationCompletedListener.run

--- a/app/models/listeners/curam_application_completed_listener.rb
+++ b/app/models/listeners/curam_application_completed_listener.rb
@@ -7,7 +7,7 @@ module Listeners
     def on_message(delivery_info, properties, payload)
       query_service = ::Proxies::CuramCaseQuery.new
       payload = extract_ic_id(payload)
-      code, body = query_service.invoke(payload, 15)
+      code, body = query_service.invoke(payload, 30)
       case code.to_s
       when "406"
         # Invalid server response - send an event


### PR DESCRIPTION
Increase the allowed timeout for Curam application requests, and make Kubernetes manage child processes, instead of the legacy library.

[IVL Product Development - 185792240](https://www.pivotaltracker.com/story/show/185792240)